### PR TITLE
Add DB logging & add album in scrobbling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 <!-- TODO -->
-<!-- get inspo from https://github.com/Ladbaby/lastfm-scrobbler -->
-<!-- no inspo but alt https://github.com/YodaEmbedding/scrobblez -->
-<!-- no inspo but alt https://github.com/InputUsername/rescrobbled -->
 <!-- https://github.com/ahmagdy/lyricsify?tab=readme-ov-file -->
 <!-- https://github.com/SwagLyrics/SwagLyrics-For-Spotify/tree/master -->
 
@@ -9,19 +6,19 @@
 
 ![Demo of the Query Functionality](./assets/query-demo.gif)
 
--   [About](#about)
--   [Requirements](#requirements)
--   [Installation](#installation)
--   [Usage](#usage)
-    -   [Querying & Playing Music](#querying---playing-music)
-    -   [Live Results](#live-results)
-    -   [Tags](#tags)
-    -   [Spotify Integration](#spotify-integration)
-    -   [Auto Completion](#auto-completion)
-    -   [Lastfm Scrobbling](#lastfm-scrobbling)
-    -   [Lastfm Suggestions](#lastfm-suggestions)
-    -   [Android](#android)
-    -   [Configuration](#configuration)
+- [About](#about)
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Querying & Playing Music](#querying---playing-music)
+  - [Live Results](#live-results)
+  - [Tags](#tags)
+  - [Lastfm Scrobbling](#lastfm-scrobbling)
+  - [Lastfm Suggestions](#lastfm-suggestions)
+  - [Spotify Integration](#spotify-integration)
+  - [Auto Completion](#auto-completion)
+  - [Android](#android)
+  - [Configuration](#configuration)
 
 ## About
 
@@ -37,8 +34,8 @@ This program does not support piracy; you should have the rights to all your fil
 
 ## Requirements
 
--   VLC (if you plan on listening to music or scrobbling)
--   playerctl (if you plan on scrobbling to lastfm with vlc)
+- VLC (if you plan on listening to music or scrobbling)
+- playerctl (if you plan on scrobbling to lastfm with vlc)
 
 ## Installation
 
@@ -89,11 +86,11 @@ music play tonight monday#mornings care,bear,say make#you,me#believe \!joe
 
 There are four terms here:
 
--   `tonight` (song has to have the word "tonight" somewhere in the path)
--   `monday#mornings` (song has to have both words "monday" and "mornings" (not necessarily next to each other))
--   `care,bear,say` (song has to have one or more of "care", "bear", "say")
--   `make#you,me#believe` (song has to have "make", either "you" or "me", and "believe")
--   `\!joe` (the song can't have the term, notice the escaping of "!")
+- `tonight` (song has to have the word "tonight" somewhere in the path)
+- `monday#mornings` (song has to have both words "monday" and "mornings" (not necessarily next to each other))
+- `care,bear,say` (song has to have one or more of "care", "bear", "say")
+- `make#you,me#believe` (song has to have "make", either "you" or "me", and "believe")
+- `\!joe` (the song can't have the term, notice the escaping of "!")
 
 When combining these terms, the string is split by `#` first, and then `,`.
 
@@ -128,6 +125,74 @@ The intended way to add songs to a tag is to query the songs with `music play`
 and then using `--add-to-tag | -a <tag>` or `--set-to-tag | -s <tag>`. If you
 need to query but don't want to actually play the songs you can add `--dry-run`.
 
+### Lastfm Scrobbling
+
+While VLC does have built in lastfm scrobbling, I could not get it to work
+(edit: I actually got it to work, but it doesn't scrobble certain tracks and I
+kinda already built this so whatever). You can run a watch server to watch for
+playing songs every x seconds (defaulted to 10). It uses playerctl (MPRIS)
+under the hood, so you will need to have that installed and be on linux (in the
+future I could add vlc tcp support so that non-linux users could also use). It
+also only checks for the VLC player so other media players or something like
+youtube will not be logged. An alternative would be
+[multi-scrobbler](https://github.com/FoxxMD/multi-scrobbler) which supports a
+lot more sources, and has a lot more functionality overall.
+
+Currently, the scrobble detection is kind of poor. It follows the approach of
+minimizing false positives, so if you skip/seek around, it likely won't
+scrobble. Also, if you play the same song over and over it won't scrobble more
+than once (although this will be fixed in the future).
+
+Lastly, it follows the [lastfm standards](https://www.last.fm/api/scrobbling):
+
+1.  The track must be longer than 30 seconds.
+2.  The track has been played for at least half its duration, or for 4 minutes (whichever occurs earlier.)
+
+To get started first make an api account and application on [last.fm](https://www.last.fm/api/account/create). You then need to create a file (".lastfm-credentials") in your cache directory.
+In that file you should store your api_key and your api_secret:
+
+```
+api_key=xxxxx
+api_secret=yyyy
+```
+
+Then just run the lastfm watch command, and it will automatically get the session_key:
+
+```
+music lastfm watch --interval 20 --debug
+```
+
+I personally have this command start on startup, and I redirect the output to `/tmp/music-lastfm.log`. This program can also
+write the logs to a local sqlite database file. This is helpful for if you want to keep a local copy of your scrobbles
+and in case a valid scrobble fails (network issues or lastfm downtime). You can enable this with the `--log-db-file` flag.
+
+```
+music lastfm watch --log-db-file /home/user/.local/state/lastfm-scrobbles.db
+```
+
+If a scrobble fails, it will not be retried automatically or on the next run, but you can use the `music lastfm import` to import
+all the failed scrobbles from the database file.
+
+### Lastfm Scrobbler Alternatives
+
+There are a few alternatives to this scrobbling functionality. In particular, one thing this program does not include that many others do, is some way to edit/filter artist/titles/albums before scrobbling. I personally don't need it, as I only use this program for local files, and if there is an error with my metadata I fix it at the source using `atomicparsley`. Similarly, I don't include any other MPRIS player other than VLC as that's the only one I use (and I'm not sure anyone else uses this). However, I understand that these are useful features for many people.
+
+I have not tried any of the following, so I don't necessarily endorse them, but they are worth checking out:
+
+- [YodaEmbedding/scrobblez](https://github.com/YodaEmbedding/scrobblez) last update was 6 years ago, so actually, maybe not this one
+- [Ladbaby/lastfm-scrobbler](https://github.com/Ladbaby/lastfm-scrobbler)
+- [InputUsername/rescobbled](https://github.com/InputUsername/rescrobbled)
+
+### Lastfm Suggestions
+
+You can also get lastfm suggestions (on any OS, without authentication) with the suggest command.
+
+```
+music lastfm suggest username --limit 20
+```
+
+If you would like to automatically install the music add the `--install` flag which will install to `$MUSIC_PATH/Suggestions`.
+
 ### Spotify Integration
 
 You can also sync Spotify playlists and albums with local tags. To get started first
@@ -135,10 +200,10 @@ create a Spotify developer account and make an application. Then create a file "
 
 Your cache directory is determined by Go below:
 
--   On Unix systems, it returns `$XDG_CACHE_HOME` as specified by https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html if non-empty, else $HOME/.cache.
--   On Darwin, it returns `$HOME/Library/Caches`
--   On Windows, it returns `%LocalAppData%`
--   On Plan 9, it returns `$home/lib/cache`
+- On Unix systems, it returns `$XDG_CACHE_HOME` as specified by https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html if non-empty, else $HOME/.cache.
+- On Darwin, it returns `$HOME/Library/Caches`
+- On Windows, it returns `%LocalAppData%`
+- On Plan 9, it returns `$home/lib/cache`
 
 In your new file you should store your client_id and client_secret:
 
@@ -192,63 +257,14 @@ The cobra provided completion is also a bit more descriptive than I personally
 like, which is why I use my own personal bash completion. It can be found in
 `./completion.bash`
 
--   Note: I have `m` as an alias for `music` and `mx` as an alias for `music play`
--   Note: It's also more static/hard-coded, so a bit more error-prone/inaccurate.
-
-### Lastfm Scrobbling
-
-While VLC does have built in lastfm scrobbling, I could not get it to work
-(edit: I actually got it to work, but it doesn't scrobble certain tracks and I
-kinda already built this so whatever). You can run a watch server to watch for
-playing songs every x seconds (defaulted to 10). It uses playerctl (MPRIS)
-under the hood, so you will need to have that installed and be on linux (in the
-future I could add vlc tcp support so that non-linux users could also use). It
-also only checks for the VLC player so other media players or something like
-youtube will not be logged. An alternative would be
-[multi-scrobbler](https://github.com/FoxxMD/multi-scrobbler) which supports a
-lot more sources, and has a lot more functionality overall.
-
-Currently, the scrobble detection is kind of poor. It follows the approach of
-minimizing false positives, so if you skip/seek around, it likely won't
-scrobble. Also, if you play the same song over and over it won't scrobble more
-than once (although this will be fixed in the future).
-
-Lastly, it follows the [lastfm standards](https://www.last.fm/api/scrobbling):
-
-1.  The track must be longer than 30 seconds.
-2.  The track has been played for at least half its duration, or for 4 minutes (whichever occurs earlier.)
-
-To get started first make an api account and application on [last.fm](https://www.last.fm/api/account/create). You then need to create a file (".lastfm-credentials") in your cache directory.
-In that file you should store your api_key and your api_secret:
-
-```
-api_key=xxxxx
-api_secret=yyyy
-```
-
-Then just run the lastfm watch command, and it will automatically get the session_key:
-
-```
-music lastfm watch --interval 20 --debug
-```
-
-I personally have this command start on startup, and I redirect the output to `/tmp/music-lastfm.log`.
-
-### Lastfm Suggestions
-
-You can also get lastfm suggestions (on any OS, without authentication) with the suggest command.
-
-```
-music lastfm suggest username --limit 20
-```
-
-If you would like to automatically install the music add the `--install` flag which will install to `$MUSIC_PATH/Suggestions`.
+- Note: I have `m` as an alias for `music` and `mx` as an alias for `music play`
+- Note: It's also more static/hard-coded, so a bit more error-prone/inaccurate.
 
 ### Android
 
 If you would like to use the one of main functionalities of querying on android,
 you can do so using Termux. You will likely have to install go first and then
-follow the instructions in #installation.
+follow the instructions in [#installation](#installation).
 
 After you have the music command installed, you want to download the wrapper script
 in `./android-termux-mx`. This script calls the play command with the given query
@@ -273,7 +289,7 @@ hanging, and you won't have vlc in your notification tray.
 
 The configuration file is located in `<$CONFIG_DIR>/go-music-kitesi/config.json`. An example can be found in [assets/default-config.json](assets/default-config.json). `<$CONFIG_DIR>` is specified as below:
 
--   On Unix systems, it returns $XDG_CONFIG_HOME as specified by https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html if non-empty, else $HOME/.config.
--   On Darwin, it returns `$HOME/Library/Application Support`.
--   On Windows, it returns `%AppData%`.
--   On Plan 9, it returns `$home/lib`.
+- On Unix systems, it returns $XDG_CONFIG_HOME as specified by https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html if non-empty, else $HOME/.config.
+- On Darwin, it returns `$HOME/Library/Application Support`.
+- On Windows, it returns `%AppData%`.
+- On Plan 9, it returns `$home/lib`.

--- a/assets/default-config.json
+++ b/assets/default-config.json
@@ -1,10 +1,10 @@
 {
-    "musicPath": "/home/username/Music",
-    "debug": false,
-    "lastfm": {
-        "interval": 10,
-        "minTrackLength": 30,
-        "minListenTime": 240
-        "logDbFile": "/home/username/.local/state/music.db"
-    }
+  "musicPath": "/home/username/Music",
+  "debug": false,
+  "lastfm": {
+    "interval": 10,
+    "minTrackLength": 30,
+    "minListenTime": 240,
+    "logDbFile": "/home/username/.local/state/music.db"
+  }
 }

--- a/assets/default-config.json
+++ b/assets/default-config.json
@@ -5,5 +5,6 @@
         "interval": 10,
         "minTrackLength": 30,
         "minListenTime": 240
+        "logDbFile": "/home/username/.local/state/music.db"
     }
 }

--- a/commands/lastfm/import.go
+++ b/commands/lastfm/import.go
@@ -23,7 +23,7 @@ func ImportSetup() *cobra.Command {
 
 	lastfmCommand := &cobra.Command{
 		Use:   "import <log-db-file>",
-		Short: "Import unfilled songs from ",
+		Short: "Import unfulfilled scrobbled from a database file",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, positional []string) {
 			if err := importRunner(positional[0], &args); err != nil {

--- a/commands/lastfm/import.go
+++ b/commands/lastfm/import.go
@@ -2,17 +2,16 @@ package lastfm
 
 import (
 	"bufio"
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
-	"regexp"
+	"strconv"
 	"strings"
-	"time"
 
+	dbUtils "github.com/kitesi/music/db"
 	"github.com/kitesi/music/utils"
 	"github.com/spf13/cobra"
 )
@@ -23,8 +22,8 @@ func ImportSetup() *cobra.Command {
 	args := LastfmImportArgs{}
 
 	lastfmCommand := &cobra.Command{
-		Use:   "import <file> [one of -j or -t]",
-		Short: "Note: maybe not the clearest documentation since I don't suspect many will use this. Feel free to create a github issue if you need help! Import songs from a json file exported by the recent command, or by a text file that contains log output from the watch command.",
+		Use:   "import <log-db-file>",
+		Short: "Import unfilled songs from ",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, positional []string) {
 			if err := importRunner(positional[0], &args); err != nil {
@@ -44,117 +43,11 @@ func ImportSetup() *cobra.Command {
 	}
 
 	lastfmCommand.Flags().BoolVarP(&args.debug, "debug", "d", config.Debug, "set debug mode")
-	lastfmCommand.Flags().BoolVarP(&args.json, "json", "j", false, "input file is in json format")
-	lastfmCommand.Flags().BoolVarP(&args.text, "text", "t", false, "input file is in text format from watch --debug")
 	return lastfmCommand
 }
 
-func importJsonFile(fileContents []byte) ([]PossibleRedoScrobble, error) {
-	var resultJson GetRecentTracksResponse
-	err := json.Unmarshal(fileContents, &resultJson)
-	songsToScrobble := []PossibleRedoScrobble{}
-
-	if err != nil {
-		return songsToScrobble, err
-	}
-
-	for _, track := range resultJson.RecentTracks.Track {
-		songsToScrobble = append(songsToScrobble, PossibleRedoScrobble{
-			Artist: track.Artist.Text,
-			Track:  track.Name,
-			Time:   fmt.Sprintf("%d", track.Date.Uts),
-		})
-	}
-
-	return songsToScrobble, nil
-}
-
-/*
-In the format of:
-
-info : 2024/11/24 15:45:00 └── scrobbling because it is over half way through (listened for 167.50, real: 130.00, half len: 80.50, min: 240)
-info : 2024/11/24 15:45:30 new song detected - Christina Perri - human
-info : 2024/11/24 15:45:40 └── not scrobbling because it did not pass either listen condition (listened for -23.80, real: 10.00, half len: 122.00, min: 240)
-info : 2024/11/24 15:45:40 new song detected - Kendrick Lamar - Swimming Pools (Drank)
-info : 2024/11/24 16:24:20 └── scrobbling because it is over half way through (listened for 246.79, real: 2320.00, half len: 124.00, min: 24j)
-info : 2024/11/24 17:06:46 new song detected - AnnenMayKantereit & Giant Rooks - Tom's Diner
-info : 2024/11/24 17:08:27 └── not scrobbling because it did not pass either listen condition (listened for 99.75, real: 101.00, half len: 136.50, min: 240)
-
-Basically the idea is the program will extract all the songs that have been attempted to be scrolled to in this text file, and rescrobble it.
-There are two reasons for doing this:
-
-1. Maybe you don't have wifi, and thus the scrobble will fail.
-2. Maybe you do have wifi but it just failed for some reason. (it's possible that lastfm will send an error which will be logged,
-but it's also possible that lastfm will state everything went fine when in reality it didn't)
-3. Maybe you were logged in to the wrong account.
-
-I def want to introduce a better method for the first cause though. It should automatically retry scrobbling when it can.
-*/
-
-type PossibleRedoScrobble struct {
-	Artist string
-	Track  string
-	Time   string
-}
-
-func importTextFile(fileContents []byte) ([]PossibleRedoScrobble, error) {
-	scanner := bufio.NewScanner(bytes.NewReader(fileContents))
-	songsToScrobble := []PossibleRedoScrobble{}
-	captureRegex := regexp.MustCompile(`info : (.+) (.+) new song detected - (.+) - (.+)`)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		if strings.Contains(line, "new song detected") {
-			if scanner.Scan() {
-				nextLine := scanner.Text()
-
-				if strings.Contains(nextLine, "─ scrobbling") {
-					matches := captureRegex.FindStringSubmatch(line)
-
-					if len(matches) == 5 {
-						layout := "2006/01/02 15:04:05"
-						parsedTime, err := time.Parse(layout, matches[1]+" "+matches[2])
-
-						if err != nil {
-							return nil, fmt.Errorf("error parsing time: %s from line %s\n", err, line)
-						}
-
-						songsToScrobble = append(songsToScrobble, PossibleRedoScrobble{
-							Artist: matches[3],
-							Track:  matches[4],
-							Time:   fmt.Sprintf("%d", parsedTime.Unix()),
-						})
-					}
-
-				}
-			}
-
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-
-	return songsToScrobble, nil
-}
-
-func importRunner(file string, args *LastfmImportArgs) error {
-	if args.json && args.text {
-		return fmt.Errorf("only one of --json/-j or --text/-t can be used")
-	} else if !args.json && !args.text {
-		return fmt.Errorf("one of --json/-t or --text/-t must be used")
-	}
-
+func importRunner(filename string, _ *LastfmImportArgs) error {
 	credentials, err := setupOrGetCredentials()
-
-	if err != nil {
-		return err
-	}
-
-	// read file contents
-	fileContents, err := os.ReadFile(file)
 
 	if err != nil {
 		return err
@@ -164,30 +57,37 @@ func importRunner(file string, args *LastfmImportArgs) error {
 	apiSecret, _ := credentials.Get("api_secret")
 	sessionKey, _ := credentials.Get("session_key")
 
-	var todo []PossibleRedoScrobble
+	_, err = os.Stat(filename)
 
-	if args.json {
-		todo, err = importJsonFile(fileContents)
-	} else {
-		todo, err = importTextFile(fileContents)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("file %s does not exist", filename)
 	}
+
+	db, err := dbUtils.OpenDB(filename)
+	songsToScrobble, err := dbUtils.GetUnfulfilledPlays(db)
 
 	if err != nil {
 		return err
 	}
 
+	defer db.Close()
+
 	cursor := 0
 
-	if len(todo) > MAX_SCROBBLES {
+	if len(songsToScrobble) > MAX_SCROBBLES {
 		fmt.Printf("There are more than %d songs to scrobble. This program will scrobble %d songs at a time.\n", MAX_SCROBBLES, MAX_SCROBBLES)
 	}
 
-	// todo: add total sucessful and stuff
-	for cursor < len(todo) {
+	if len(songsToScrobble) == 0 {
+		fmt.Println("No songs to scrobble.")
+		return nil
+	}
+
+	for cursor < len(songsToScrobble) {
 		endPosition := cursor + MAX_SCROBBLES
 
-		if endPosition > len(todo) {
-			endPosition = len(todo)
+		if endPosition > len(songsToScrobble) {
+			endPosition = len(songsToScrobble)
 		}
 
 		amountOfScrobbles := endPosition - cursor
@@ -198,11 +98,12 @@ func importRunner(file string, args *LastfmImportArgs) error {
 		params.Set("api_key", apiKey)
 		params.Set("sk", sessionKey)
 
-		for i, song := range todo[cursor:endPosition] {
-			fmt.Println(i+1, song.Artist, song.Track, song.Time)
+		for i, song := range songsToScrobble[cursor:endPosition] {
+			timeStr := strconv.FormatInt(song.Time.Unix(), 10)
+			fmt.Println(i+1, song.Artist, song.Title, song.Time)
 			params.Set(fmt.Sprintf("artist[%d]", i), song.Artist)
-			params.Set(fmt.Sprintf("track[%d]", i), song.Track)
-			params.Set(fmt.Sprintf("timestamp[%d]", i), song.Time)
+			params.Set(fmt.Sprintf("track[%d]", i), song.Title)
+			params.Set(fmt.Sprintf("timestamp[%d]", i), timeStr)
 		}
 
 		// ask for confirmation
@@ -211,8 +112,7 @@ func importRunner(file string, args *LastfmImportArgs) error {
 		text, _ := reader.ReadString('\n')
 
 		if strings.TrimSpace(text) != "y" {
-			cursor += amountOfScrobbles
-			continue
+			break
 		}
 
 		params.Set("api_sig", generateSignature(params, apiSecret))
@@ -231,11 +131,30 @@ func importRunner(file string, args *LastfmImportArgs) error {
 		defer resp.Body.Close()
 		body, err := io.ReadAll(resp.Body)
 
-		fmt.Println(resp.StatusCode, string(body))
+		if err != nil {
+			return err
+		}
 
-		fmt.Println("Scrobbled", amountOfScrobbles, "tracks (hopefully)")
+		fmt.Println(resp.StatusCode, string(body))
+		fmt.Println("Received response code:", resp.StatusCode)
+
+		var resultJson PostMultipleScrobbleResponse
+		err = json.Unmarshal(body, &resultJson)
+
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Scrobbles accepted: %d, ignored: %d\n", resultJson.Scrobbles.Attr.Accepted, resultJson.Scrobbles.Attr.Ignored)
+
+		if resultJson.Scrobbles.Attr.Accepted == amountOfScrobbles {
+			fmt.Println("All scrobbles accepted, updating local database...")
+			dbUtils.UpdateUnfulfilledPlays(db, songsToScrobble[cursor:endPosition])
+		} else {
+			fmt.Println("Not all scrobbles were accepted, not updating local database.")
+		}
+
 		cursor += amountOfScrobbles
-		// TODO: take care of the response (does not match PostScrobbleResponse since Scrobble is an array i guess lol)
 	}
 
 	return nil

--- a/commands/lastfm/types.go
+++ b/commands/lastfm/types.go
@@ -96,6 +96,7 @@ type LastfmWatchArgs struct {
 	minTrackLength int
 	minListenTime  int
 	debug          bool
+	logDbFile      string
 }
 
 type LastfmSuggestArgs struct {

--- a/commands/lastfm/types.go
+++ b/commands/lastfm/types.go
@@ -120,6 +120,7 @@ type GetLastfmSuggestionsResponse struct {
 type CurrentTrackInfo struct {
 	Track        string
 	Artist       string
+	Album        string
 	LastPosition float64
 	StartTime    time.Time
 	Length       float64

--- a/commands/lastfm/types.go
+++ b/commands/lastfm/types.go
@@ -1,5 +1,7 @@
 package lastfm
 
+import "time"
+
 type Session struct {
 	Name       string
 	Key        string
@@ -21,6 +23,38 @@ type GetSessionResponse struct {
 type PostScrobbleResponse struct {
 	Scrobbles struct {
 		Scrobble struct {
+			Artist struct {
+				Text      string `json:"#text"`
+				Corrected string
+			}
+			Album struct {
+				Text      string `json:"#text"`
+				Corrected string
+			}
+			Track struct {
+				Text      string `json:"#text"`
+				Corrected string
+			}
+			AlbumArtist struct {
+				Text      string `json:"#text"`
+				Corrected string
+			}
+			IgnoredMessage struct {
+				Code string
+				Text string `json:"#text"`
+			}
+			Timestamp string
+		}
+		Attr struct {
+			Ignored  int
+			Accepted int
+		} `json:"@attr"`
+	}
+}
+
+type PostMultipleScrobbleResponse struct {
+	Scrobbles struct {
+		Scrobble []struct {
 			Artist struct {
 				Text      string `json:"#text"`
 				Corrected string
@@ -87,7 +121,7 @@ type CurrentTrackInfo struct {
 	Track        string
 	Artist       string
 	LastPosition float64
-	StartTime    int64
+	StartTime    time.Time
 	Length       float64
 }
 
@@ -117,6 +151,4 @@ type LastfmRecentArgs struct {
 
 type LastfmImportArgs struct {
 	debug bool
-	json  bool
-	text  bool
 }

--- a/commands/lastfm/watch.go
+++ b/commands/lastfm/watch.go
@@ -331,7 +331,6 @@ func attemptScrobble(db *sql.DB, credentials simpleconfig.Config, currentTrack *
 		}
 
 		stdOut.Printf("└── scrobbling because %s (%s)", reason, listenStats)
-
 		scrobbleResponse, err := scrobble(credentials, currentTrack.Artist, currentTrack.Track, currentTrack.StartTime.Unix())
 
 		if err != nil {
@@ -343,7 +342,9 @@ func attemptScrobble(db *sql.DB, credentials simpleconfig.Config, currentTrack *
 			stdErr.Printf("└── last.fm ignored this scrobble - %s", scrobbleResponse.Scrobbles.Scrobble.IgnoredMessage.Text)
 		}
 
-		dbUtils.InsertIntoPlays(db, insertParams)
+		if db != nil {
+			dbUtils.InsertIntoPlays(db, insertParams)
+		}
 	} else {
 		stdOut.Printf("└── not scrobbling because while it did pass the time condition, the real time did not pass (%s)", listenStats)
 	}

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -1,0 +1,68 @@
+package dbUtils
+
+import "database/sql"
+
+type Migration struct {
+	Version int
+	Up      string
+}
+
+var migrations = []Migration{
+	{
+		Version: 1,
+		Up: `
+		create table plays (
+			id integer primary key autoincrement,
+			fulfilled boolean not null,
+			title text not null,
+			artist text not null,
+			time timestamp not null
+		);
+		`,
+	},
+}
+
+func getCurrentVersion(db *sql.DB) (int, error) {
+	var v int
+	err := db.QueryRow(`
+			select coalesce(max(version),0) from schema_migrations;
+	`).Scan(&v)
+	return v, err
+}
+
+func RunMigrations(db *sql.DB) error {
+	_, err := db.Exec(`
+			create table if not exists schema_migrations (
+			version integer primary key
+		);
+	`)
+
+	if err != nil {
+		return err
+	}
+
+	currentVersion, err := getCurrentVersion(db)
+
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+
+	for _, m := range migrations {
+		if m.Version < currentVersion {
+			continue
+		}
+
+		if _, err := tx.Exec(m.Up); err != nil {
+			tx.Rollback()
+			return err
+		}
+
+		if _, err := tx.Exec("insert into schema_migrations (version) values (?)", m.Version); err != nil {
+			tx.Rollback()
+			return err
+		}
+	}
+
+	return tx.Commit()
+}

--- a/db/open.go
+++ b/db/open.go
@@ -1,0 +1,15 @@
+package dbUtils
+
+import (
+	"database/sql"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func OpenDB(filePath string) (*sql.DB, error) {
+	db, err := sql.Open("sqlite3", filePath)
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}

--- a/db/open.go
+++ b/db/open.go
@@ -8,6 +8,7 @@ import (
 
 func OpenDB(filePath string) (*sql.DB, error) {
 	db, err := sql.Open("sqlite3", filePath)
+
 	if err != nil {
 		return nil, err
 	}

--- a/db/queries.go
+++ b/db/queries.go
@@ -1,0 +1,89 @@
+package dbUtils
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type Play struct {
+	ID        int64
+	Fulfilled bool
+	Title     string
+	Artist    string
+	Time      time.Time
+}
+
+type InsertIntoPlaysParams struct {
+	Fulfilled bool
+	Title     string
+	Artist    string
+	Time      time.Time
+}
+
+const INSERT_INTO_PLAYS_QUERY = `
+	insert into plays (fulfilled, title, artist, time) values (?, ?, ?, ?)
+`
+
+func InsertIntoPlays(db *sql.DB, params InsertIntoPlaysParams) error {
+	_, err := db.Exec(
+		INSERT_INTO_PLAYS_QUERY,
+		params.Fulfilled,
+		params.Title,
+		params.Artist,
+		params.Time,
+	)
+	return err
+}
+
+// for now no pagination, just assume we can fit all unfulfilled plays in memory
+const GET_UNFULFILLED_PLAYS_QUERY = `
+	select * from plays where fulfilled = false;
+`
+
+func GetUnfulfilledPlays(db *sql.DB) ([]Play, error) {
+	rows, err := db.Query(GET_UNFULFILLED_PLAYS_QUERY)
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+	var plays []Play
+
+	for rows.Next() {
+		var play Play
+		if err := rows.Scan(&play.ID, &play.Fulfilled, &play.Title, &play.Artist, &play.Time); err != nil {
+			return nil, err
+		}
+		plays = append(plays, play)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return plays, nil
+}
+
+const UPDATE_UNFULFILLED_PLAYS_QUERY_HELPER = `
+	update plays set fulfilled = true where id in (%s)
+`
+
+func UpdateUnfulfilledPlays(db *sql.DB, plays []Play) error {
+	if len(plays) == 0 {
+		return nil
+	}
+
+	placeholders := make([]string, len(plays))
+	args := make([]any, len(plays))
+
+	for i, play := range plays {
+		placeholders[i] = "?"
+		args[i] = play.ID
+	}
+
+	query := fmt.Sprintf(UPDATE_UNFULFILLED_PLAYS_QUERY_HELPER, strings.Join(placeholders, ","))
+	_, err := db.Exec(query, args...)
+	return err
+}

--- a/db/queries.go
+++ b/db/queries.go
@@ -19,11 +19,14 @@ type InsertIntoPlaysParams struct {
 	Fulfilled bool
 	Title     string
 	Artist    string
-	Time      time.Time
+	Album     string
+	PlayedFor int
+	Length    int
+	StartTime time.Time
 }
 
 const INSERT_INTO_PLAYS_QUERY = `
-	insert into plays (fulfilled, title, artist, time) values (?, ?, ?, ?)
+	insert into plays (fulfilled, title, artist, album, playedFor, length, time) values (?, ?, ?, ?, ?, ?, ?)
 `
 
 func InsertIntoPlays(db *sql.DB, params InsertIntoPlaysParams) error {
@@ -32,7 +35,10 @@ func InsertIntoPlays(db *sql.DB, params InsertIntoPlaysParams) error {
 		params.Fulfilled,
 		params.Title,
 		params.Artist,
-		params.Time,
+		params.Album,
+		params.PlayedFor,
+		params.Length,
+		params.StartTime,
 	)
 	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/adrg/strutil v0.3.1 // indirect
 	github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/mattn/go-sqlite3 v1.14.33 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
 	golang.org/x/text v0.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaU
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/mattn/go-sqlite3 v1.14.33 h1:A5blZ5ulQo2AtayQ9/limgHEkFreKj1Dv226a1K73s0=
+github.com/mattn/go-sqlite3 v1.14.33/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/main.go
+++ b/main.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	"fmt"
-
 	cmd "github.com/kitesi/music/commands"
 )
 
 func main() {
-	fmt.Println("hi")
 	cmd.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -1,8 +1,6 @@
 package main
 
-import (
-	cmd "github.com/kitesi/music/commands"
-)
+import cmd "github.com/kitesi/music/commands"
 
 func main() {
 	cmd.Execute()

--- a/main.go
+++ b/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"fmt"
+
 	cmd "github.com/kitesi/music/commands"
 )
 
 func main() {
+	fmt.Println("hi")
 	cmd.Execute()
 }

--- a/utils/config.go
+++ b/utils/config.go
@@ -55,6 +55,7 @@ func DefaultConfig() Config {
 			Interval:       DEFAULT_INTERVAL_SECONDS,
 			MinTrackLength: MIN_TRACK_LEN,
 			MinListenTime:  MIN_LISTEN_TIME,
+			LogDbFile:      "",
 		},
 	}
 }

--- a/utils/config.go
+++ b/utils/config.go
@@ -21,6 +21,7 @@ type LastfmConfig struct {
 	Interval       int
 	MinTrackLength int
 	MinListenTime  int
+	LogDbFile      string
 }
 
 type Config struct {

--- a/utils/get-current-song.go
+++ b/utils/get-current-song.go
@@ -6,6 +6,7 @@ import (
 )
 
 type SongMetadata struct {
+	Album  string
 	Artist string
 	Track  string
 	Length string
@@ -54,6 +55,7 @@ func GetCurrentPlayingSong() (SongMetadata, error) {
 
 	return SongMetadata{
 		Artist: metadata["xesam:artist"],
+		Album:  metadata["xesam:album"],
 		Track:  metadata["xesam:title"],
 		Length: metadata["vlc:time"],
 	}, nil


### PR DESCRIPTION
DB logging allows for retrying failed scrobble attempts (reason could be because your offline, lastfm is offline) etc

DB logging also helps decentralize your scribbling

Scrobbles didn't include albums as often lastfm included it, but I figured if the metadata is there already might as well since there is a distinction between automatically having it found rather than explicit